### PR TITLE
Replace string-based type hints with direct class references in datab…

### DIFF
--- a/channely/database/attachment.py
+++ b/channely/database/attachment.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import BigInteger, ForeignKey, String
@@ -5,6 +8,9 @@ from sqlalchemy.dialects.postgresql import UUID as PostgresUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from channely.database.base import BaseEntityWithoutTimestamps
+
+if TYPE_CHECKING:
+    from channely.database.content import ContentEntity
 
 
 class AttachmentEntity(BaseEntityWithoutTimestamps):
@@ -18,6 +24,6 @@ class AttachmentEntity(BaseEntityWithoutTimestamps):
     size_in_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
 
     # Relationships
-    content: Mapped["ContentEntity"] = relationship(
+    content: Mapped[ContentEntity] = relationship(
         "ContentEntity", back_populates="attachments"
     )

--- a/channely/database/channel.py
+++ b/channely/database/channel.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import ForeignKey, String
@@ -6,6 +9,11 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from channely.database.base import BaseEntity
 from channely.database.channel_status import ChannelStatus
+
+if TYPE_CHECKING:
+    from channely.database.content import ContentEntity
+    from channely.database.permissions import ChannelPermissionEntity
+    from channely.database.user import UserEntity
 
 
 class ChannelEntity(BaseEntity):
@@ -21,17 +29,17 @@ class ChannelEntity(BaseEntity):
     )
 
     # Relationships
-    creator: Mapped["UserEntity"] = relationship(
+    creator: Mapped[UserEntity] = relationship(
         "UserEntity", foreign_keys=[creator_id], back_populates="created_channels"
     )
-    parent_content: Mapped["ContentEntity"] = relationship(
+    parent_content: Mapped[ContentEntity] = relationship(
         "ContentEntity", foreign_keys=[parent_content_id], back_populates="subchannels"
     )
-    content: Mapped[list["ContentEntity"]] = relationship(
+    content: Mapped[list[ContentEntity]] = relationship(
         "ContentEntity",
         foreign_keys="ContentEntity.channel_id",
         back_populates="channel",
     )
-    permissions: Mapped[list["ChannelPermissionEntity"]] = relationship(
+    permissions: Mapped[list[ChannelPermissionEntity]] = relationship(
         "ChannelPermissionEntity", back_populates="channel"
     )

--- a/channely/database/content.py
+++ b/channely/database/content.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import ForeignKey, Text
@@ -6,6 +9,12 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from channely.database.base import BaseEntity
 from channely.database.content_status import ContentStatus
+
+if TYPE_CHECKING:
+    from channely.database.attachment import AttachmentEntity
+    from channely.database.channel import ChannelEntity
+    from channely.database.permissions import ContentPermissionEntity
+    from channely.database.user import UserEntity
 
 
 class ContentEntity(BaseEntity):
@@ -22,20 +31,20 @@ class ContentEntity(BaseEntity):
     )
 
     # Relationships
-    channel: Mapped["ChannelEntity"] = relationship(
+    channel: Mapped[ChannelEntity] = relationship(
         "ChannelEntity", foreign_keys=[channel_id], back_populates="content"
     )
-    creator_user: Mapped["UserEntity"] = relationship(
+    creator_user: Mapped[UserEntity] = relationship(
         "UserEntity", foreign_keys=[creator], back_populates="created_content"
     )
-    subchannels: Mapped[list["ChannelEntity"]] = relationship(
+    subchannels: Mapped[list[ChannelEntity]] = relationship(
         "ChannelEntity",
         foreign_keys="ChannelEntity.parent_content_id",
         back_populates="parent_content",
     )
-    attachments: Mapped[list["AttachmentEntity"]] = relationship(
+    attachments: Mapped[list[AttachmentEntity]] = relationship(
         "AttachmentEntity", back_populates="content"
     )
-    permissions: Mapped[list["ContentPermissionEntity"]] = relationship(
+    permissions: Mapped[list[ContentPermissionEntity]] = relationship(
         "ContentPermissionEntity", back_populates="content"
     )

--- a/channely/database/content_webhook.py
+++ b/channely/database/content_webhook.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from uuid import UUID
 
 from sqlalchemy import ForeignKey, Integer, String
@@ -17,7 +19,7 @@ class ContentWebhookEntity(BaseEntityWithoutTimestamps):
     event_type: Mapped[ContentEventType | None] = mapped_column()
 
     # Relationships
-    headers: Mapped[list["ContentWebhookHeaderEntity"]] = relationship(
+    headers: Mapped[list[ContentWebhookHeaderEntity]] = relationship(
         "ContentWebhookHeaderEntity", back_populates="webhook"
     )
 
@@ -32,6 +34,6 @@ class ContentWebhookHeaderEntity(BaseEntity):
     value: Mapped[str] = mapped_column(String(1024), nullable=False)
 
     # Relationships
-    webhook: Mapped["ContentWebhookEntity"] = relationship(
+    webhook: Mapped[ContentWebhookEntity] = relationship(
         "ContentWebhookEntity", back_populates="headers"
     )

--- a/channely/database/permissions.py
+++ b/channely/database/permissions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import ForeignKey, UniqueConstraint
@@ -8,6 +11,11 @@ from channely.database.base import BaseEntity, BaseEntityWithoutTimestamps
 from channely.database.channel_permission_type import ChannelPermissionType
 from channely.database.content_permission_type import ContentPermissionType
 from channely.database.system_permission_type import SystemPermissionType
+
+if TYPE_CHECKING:
+    from channely.database.channel import ChannelEntity
+    from channely.database.content import ContentEntity
+    from channely.database.user import UserEntity
 
 
 class ChannelPermissionEntity(BaseEntityWithoutTimestamps):
@@ -27,10 +35,10 @@ class ChannelPermissionEntity(BaseEntityWithoutTimestamps):
     )
 
     # Relationships
-    channel: Mapped["ChannelEntity"] = relationship(
+    channel: Mapped[ChannelEntity] = relationship(
         "ChannelEntity", back_populates="permissions"
     )
-    creator: Mapped["UserEntity"] = relationship(
+    creator: Mapped[UserEntity] = relationship(
         "UserEntity", foreign_keys=[creator_id], back_populates="channel_permissions"
     )
 
@@ -52,10 +60,10 @@ class ContentPermissionEntity(BaseEntityWithoutTimestamps):
     )
 
     # Relationships
-    content: Mapped["ContentEntity"] = relationship(
+    content: Mapped[ContentEntity] = relationship(
         "ContentEntity", back_populates="permissions"
     )
-    user: Mapped["UserEntity"] = relationship(
+    user: Mapped[UserEntity] = relationship(
         "UserEntity", foreign_keys=[user_id], back_populates="content_permissions"
     )
 
@@ -72,6 +80,6 @@ class SystemPermissionEntity(BaseEntityWithoutTimestamps):
     )
 
     # Relationships
-    user: Mapped["UserEntity"] = relationship(
+    user: Mapped[UserEntity] = relationship(
         "UserEntity", back_populates="system_permissions"
     )

--- a/channely/database/user.py
+++ b/channely/database/user.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import String
@@ -5,6 +8,15 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from channely.database.base import BaseEntity
 from channely.database.user_status import UserStatus
+
+if TYPE_CHECKING:
+    from channely.database.channel import ChannelEntity
+    from channely.database.content import ContentEntity
+    from channely.database.permissions import (
+        ChannelPermissionEntity,
+        ContentPermissionEntity,
+        SystemPermissionEntity,
+    )
 
 
 class UserEntity(BaseEntity):
@@ -17,26 +29,26 @@ class UserEntity(BaseEntity):
     theme: Mapped[str | None] = mapped_column(String(50))
 
     # Relationships
-    created_channels: Mapped[list["ChannelEntity"]] = relationship(
+    created_channels: Mapped[list[ChannelEntity]] = relationship(
         "ChannelEntity",
         foreign_keys="ChannelEntity.creator_id",
         back_populates="creator",
     )
-    created_content: Mapped[list["ContentEntity"]] = relationship(
+    created_content: Mapped[list[ContentEntity]] = relationship(
         "ContentEntity",
         foreign_keys="ContentEntity.creator",
         back_populates="creator_user",
     )
-    channel_permissions: Mapped[list["ChannelPermissionEntity"]] = relationship(
+    channel_permissions: Mapped[list[ChannelPermissionEntity]] = relationship(
         "ChannelPermissionEntity",
         foreign_keys="ChannelPermissionEntity.creator_id",
         back_populates="creator",
     )
-    content_permissions: Mapped[list["ContentPermissionEntity"]] = relationship(
+    content_permissions: Mapped[list[ContentPermissionEntity]] = relationship(
         "ContentPermissionEntity",
         foreign_keys="ContentPermissionEntity.user_id",
         back_populates="user",
     )
-    system_permissions: Mapped[list["SystemPermissionEntity"]] = relationship(
+    system_permissions: Mapped[list[SystemPermissionEntity]] = relationship(
         "SystemPermissionEntity", back_populates="user"
     )


### PR DESCRIPTION
…ase entities

- Add 'from __future__ import annotations' to all entity files to enable forward references
- Add TYPE_CHECKING imports for circular dependency resolution
- Replace all string-based Mapped[...] type hints with direct class references
- Maintain backward compatibility with SQLAlchemy relationship() string references
- All imports and database functionality tested and working correctly